### PR TITLE
Dataloader fix  (#296)

### DIFF
--- a/bittensor/dataloaders/dataloader.py
+++ b/bittensor/dataloaders/dataloader.py
@@ -37,7 +37,7 @@ class BittensorDataLoader():
         """
         parser.add_argument('--dataloader.max_corpus_size', default=1e+6, type=int, 
                                 help='Maximum amount of data to download from IPFS into memory for training.')
-        parser.add_argument('--dataloader.num_workers', default=1, type=int, 
+        parser.add_argument('--dataloader.num_workers', default=0, type=int, 
                                 help='Number of workers for data loader.')
 
     

--- a/bittensor/neuron.py
+++ b/bittensor/neuron.py
@@ -18,17 +18,10 @@
 
 
 import argparse
-import json
-import os
-import re
-import stat
 import traceback as tb
 
 from io import StringIO
 from munch import Munch
-from termcolor import colored
-from cryptography.exceptions import InvalidSignature, InvalidKey
-from cryptography.fernet import InvalidToken
 
 import bittensor
 
@@ -288,5 +281,6 @@ class Neuron:
         return self
 
     def __del__(self):
-        self.stop()
+        #self.stop()
+        pass
 


### PR DESCRIPTION
* Added fix to dataloader

* Adjusted to len of chunk

* Fixed abrupt axon stop if axon isn't instantiated

* removed call to self.top()

* Fixed len call

* Fixed len call on len(self)

* Fixed dataloader failing to download new dataset when current dataset is exhausted

* Dataloader num workers should be 0

* Added collate fn to skip None items from __getitem__